### PR TITLE
move pip caching to setup-python step

### DIFF
--- a/{{cookiecutter.hyphenated}}/.github/workflows/publish.yml
+++ b/{{cookiecutter.hyphenated}}/.github/workflows/publish.yml
@@ -16,13 +16,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/cache@v2
-      name: Configure pip caching
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
+        cache: pip
     - name: Install dependencies
       run: |
         pip install -e '.[test]'
@@ -38,13 +32,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '3.9'
-    - uses: actions/cache@v2
-      name: Configure pip caching
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-publish-pip-${{ hashFiles('**/setup.py') }}
-        restore-keys: |
-          ${{ runner.os }}-publish-pip-
+        cache: pip
     - name: Install dependencies
       run: |
         pip install setuptools wheel twine build

--- a/{{cookiecutter.hyphenated}}/.github/workflows/test.yml
+++ b/{{cookiecutter.hyphenated}}/.github/workflows/test.yml
@@ -14,13 +14,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/cache@v2
-      name: Configure pip caching
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
+        cache: pip
     - name: Install dependencies
       run: |
         pip install -e '.[test]'


### PR DESCRIPTION
Now the `setup-python` Action can cache dependencies ([GitHub blog Nov 2021](https://github.blog/changelog/2021-11-23-github-actions-setup-python-now-supports-dependency-caching/))

Instead of having the extra *Configure pip caching*  step, one can add `cache: pip` to this step
```yaml
- uses: actions/setup-python@v2
  with:
    python-version: '3.9'
    cache: 'pip'
```

I've been using this cookie-cutter template on a couple of projects now and that's one of the first edits I make so I'm opening this PR in case others might find it useful.

***
PS: The same could be done on the repo's `.github/workflows/push.yml` file.
https://github.com/simonw/python-lib/blob/d917260bfe362606d0b3693d951f742e94bcd614/.github/workflows/push.yml#L22-L32