### PR TITLE
Switch to uv and dependency-groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,17 +39,8 @@ Having created the new structure from the template, here's how to start working 
 If your library is called `my-new-library`, you can start working on it like so:
 ```bash
 cd my-new-library
-# Create and activate a virtual environment:
-python -m venv venv
-source venv/bin/activate
-# Install dependencies so you can edit the project:
-python -m pip install -e '.[test]'
-# With zsh you have to run this again for some reason:
-source venv/bin/activate
-```
-You can run the default test for your library like so:
-```bash
-python -m pytest
+# Run the tests
+uv run pytest
 ```
 This will execute the test in `tests/test_my_new_library.py`.
 

--- a/{{cookiecutter.hyphenated}}/.github/workflows/publish.yml
+++ b/{{cookiecutter.hyphenated}}/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
         cache-dependency-path: pyproject.toml
     - name: Install dependencies
       run: |
-        pip install '.[test]'
+        pip install . --group dev
     - name: Run tests
       run: |
         python -m pytest

--- a/{{cookiecutter.hyphenated}}/.github/workflows/test.yml
+++ b/{{cookiecutter.hyphenated}}/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         cache-dependency-path: pyproject.toml
     - name: Install dependencies
       run: |
-        pip install '.[test]'
+        pip install . --group dev
     - name: Run tests
       run: |
         python -m pytest

--- a/{{cookiecutter.hyphenated}}/.gitignore
+++ b/{{cookiecutter.hyphenated}}/.gitignore
@@ -9,3 +9,4 @@ venv
 .DS_Store
 dist
 build
+uv.lock

--- a/{{cookiecutter.hyphenated}}/pyproject.toml
+++ b/{{cookiecutter.hyphenated}}/pyproject.toml
@@ -11,12 +11,15 @@ dependencies = [
 
 ]
 
+[dependency-groups]
+dev = [
+    "pytest"
+]
+
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
-[tool.uv]
-package = true
 {% if cookiecutter.github_username %}
 [project.urls]
 Homepage = "https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.hyphenated }}"
@@ -24,6 +27,3 @@ Changelog = "https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutt
 Issues = "https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.hyphenated }}/issues"
 CI = "https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.hyphenated }}/actions"
 {% endif %}
-
-[project.optional-dependencies]
-test = ["pytest"]


### PR DESCRIPTION
- Replace [project.optional-dependencies] with [dependency-groups] in pyproject.toml
- Remove [tool.uv] section
- Update GitHub Actions workflows to use pip install . --group dev
- Simplify README development instructions to use uv run pytest
- Add uv.lock to .gitignore

See https://til.simonwillison.net/uv/dependency-groups